### PR TITLE
Reduce number of logins to QBus EqoWeb

### DIFF
--- a/deploy/k8s/solar-prod-alert.yml
+++ b/deploy/k8s/solar-prod-alert.yml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true # allows to connect to the host-network and detect devices via mdns
       containers:
       - name: solar-prod-alert
-        image: fgheysels/solarpoweralerter:0.0.15
+        image: fgheysels/solarpoweralerter:0.0.16
         env:
         - name: Logging__LogLevel__Default
           value: Information

--- a/deploy/k8s/solar-prod-alert.yml
+++ b/deploy/k8s/solar-prod-alert.yml
@@ -15,8 +15,10 @@ spec:
       hostNetwork: true # allows to connect to the host-network and detect devices via mdns
       containers:
       - name: solar-prod-alert
-        image: fgheysels/solarpoweralerter:0.0.7
+        image: fgheysels/solarpoweralerter:0.0.15
         env:
+        - name: Logging__LogLevel__Default
+          value: Information
         - name: HomeWizard__P1HostName
           value: p1meter-015AB0
         - name: QBus__IpAddress

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/HomeWizard/HomeWizardDeviceResolver.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/HomeWizard/HomeWizardDeviceResolver.cs
@@ -18,7 +18,7 @@ namespace Fg.SolarProductionAlerter.HomeWizard
 
             foreach (var device in results)
             {
-                logger.LogDebug($"Device {device.DisplayName} found");
+                logger.LogDebug($"Device {device.DisplayName} found at IP {device.IPAddress}");
                 devices.Add(new HomeWizardDevice(device.DisplayName, device.IPAddress));
             }
 

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/PowerUsageDeterminator.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/PowerUsageDeterminator.cs
@@ -19,7 +19,7 @@ namespace Fg.SolarProductionAlerter
         {
             var currentPowerUsage = await _homeWizard.GetCurrentMeasurements();
 
-            _logger.LogInformation($"Power Usage: {currentPowerUsage.ActivePowerInWatt} watt");
+            _logger.LogDebug($"Power Usage: {currentPowerUsage.ActivePowerInWatt} watt");
 
             if (currentPowerUsage.ActivePowerInWatt <= thresholds.ExtremeOverProductionThreshold)
             {

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSession.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSession.cs
@@ -136,7 +136,7 @@ namespace Fg.SolarProductionAlerter.Qbus
 
             if (response.Type != 13)
             {
-                throw new InvalidOperationException("Setting control-item value failed");
+                throw new InvalidOperationException($"Setting control-item value failed - {response.Type}={response.Value}");
             }
         }
 
@@ -158,12 +158,12 @@ namespace Fg.SolarProductionAlerter.Qbus
 
             var response = await _httpClient.SendAsync(message);
 
+            var responseContent = await response.Content.ReadAsStringAsync();
+
             if (response.IsSuccessStatusCode == false)
             {
-                throw new HttpRequestException("EqoWeb request failed");
+                throw new HttpRequestException("EqoWeb request failed - " + responseContent);
             }
-
-            var responseContent = await response.Content.ReadAsStringAsync();
 
             return JsonSerializer.Deserialize<EqoWebResponse<TResponse>>(responseContent);
         }

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSession.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSession.cs
@@ -28,18 +28,38 @@ namespace Fg.SolarProductionAlerter.Qbus
                 throw new Exception("Login to QBUS failed");
             }
 
-            return new EqoWebSession(address, port, response.Value.Id);
+            return new EqoWebSession(address, port, response.Value.Id, DateTime.UtcNow);
         }
 
         private readonly string _sessionCookie;
         private readonly string _address;
         private readonly int _port;
+        private readonly DateTime _sessionStartTime;
 
-        private EqoWebSession(string address, int port, string sessionCookie)
+        private EqoWebSession(string address, int port, string sessionCookie, DateTime sessionStartTime)
         {
             _address = address;
             _port = port;
             _sessionCookie = sessionCookie;
+            _sessionStartTime = sessionStartTime;
+        }
+
+        public TimeSpan SessionLifeTime
+        {
+            get
+            {
+                return DateTime.UtcNow - _sessionStartTime;
+            }
+        }
+
+        private readonly TimeSpan MaxSessionLifeTime = TimeSpan.FromMinutes(20);
+
+        public bool IsExpired
+        {
+            get
+            {
+                return SessionLifeTime > MaxSessionLifeTime;
+            }
         }
 
         public async Task<IEnumerable<ControlItem>> GetSolarIndicatorControlItems(QbusConfigurationSettings settings)

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSessionRegistry.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Qbus/EqoWebSessionRegistry.cs
@@ -1,0 +1,32 @@
+﻿using Fg.SolarProductionAlerter.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Fg.SolarProductionAlerter.Qbus
+{
+    internal static class EqoWebSessionRegistry
+    {
+        private static EqoWebSession _currentSession;
+
+        /// <summary>
+        /// Gets an active QBus EqoWebSession.
+        /// </summary>
+        /// <remarks>Only initiates a new session when there's no existing session or the existing session is expired.</remarks>
+        /// <param name="qbusSettings"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        internal static async Task<EqoWebSession> GetSessionAsync(QbusConfigurationSettings qbusSettings, ILogger logger)
+        {
+            if (_currentSession == null || _currentSession.IsExpired)
+            {
+                if (_currentSession != null)
+                {
+                    logger.LogDebug($"Current session is active for {_currentSession.SessionLifeTime} and is expired - creating new session");
+                }
+
+                _currentSession = await EqoWebSession.CreateSessionAsync(qbusSettings.IpAddress, qbusSettings.Port, qbusSettings.Username, qbusSettings.Password);
+            }
+
+            return _currentSession;
+        }
+    }
+}


### PR DESCRIPTION
Only create a new QBus session when we assume the current session is expired.  This reduces the amount of logins to QBus controller.