### PR TITLE
chore: remove unnecessary dependency

### DIFF
--- a/deploy/k8s/solar-prod-alert.yml
+++ b/deploy/k8s/solar-prod-alert.yml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true # allows to connect to the host-network and detect devices via mdns
       containers:
       - name: solar-prod-alert
-        image: fgheysels/solarpoweralerter:0.0.16
+        image: fgheysels/solarpoweralerter:0.0.17
         env:
         - name: Logging__LogLevel__Default
           value: Information

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter.csproj
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
-    <PackageReference Include="Zeroconf" Version="3.7.16" />
   </ItemGroup>
 
 </Project>

--- a/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Program.cs
+++ b/src/Fg.SolarProductionAlerter/Fg.SolarProductionAlerter/Program.cs
@@ -9,6 +9,10 @@ namespace Fg.SolarProductionAlerter
 {
     internal class Program
     {
+        protected Program()
+        {
+        }
+
         static async Task Main(string[] args)
         {
             var cts = new CancellationTokenSource();
@@ -110,7 +114,7 @@ namespace Fg.SolarProductionAlerter
                 var waitTime = DateTime.Now.Date.AddDays(1).Add(FiveInTheMorning) - DateTime.Now;
 
                 logger.LogDebug($"It's evening - waiting until next morning before checking status again.  That is {waitTime} of sleep");
-                
+
                 return waitTime;
             }
 


### PR DESCRIPTION
The direct dependency on Zeroconf has been removed as this program no longer uses this package directly.
Instead, we're making use of the Fg.HomeWizard.EnergyApi.Client package which contains the logic to discover the Homewizard and communicate with it.